### PR TITLE
Update GaanaController.js

### DIFF
--- a/code/js/controllers/GaanaController.js
+++ b/code/js/controllers/GaanaController.js
@@ -7,7 +7,7 @@
     siteName: "Gaana",
     playPause: ".playPause",
     playNext: ".next",
-    playPrev: ".prev",
+    playPrev: ".previous",
     mute: ".mute",
 
     playState: ".playPause.pause"


### PR DESCRIPTION
It seems 'previous track' class name got changed on Gaana.com. Hence this correction to make the 'previous' key stroke work there.